### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,10 @@
 
 ## Clear Linux OS Distribution Project
 
-This project is currently only used to track generic non-package
-specific issues.  We may close issues that are upstream package issues
-with the request that you file issues in that project. To file an
-issue, visit the github project page and click on 'issues'.
+This github project is used to track issues related to the Clear Linux OS Distribution.
+To elaborate, this project tracks issues related to the way Clearlinux packs software or requests about software that the ClearLinux OS should include
+
+We may close issues that are related to the upstream package with the request that you file issues in that project.
+
+
+If you find and issue in the Clear Linux OS Distribution, please visit the [github project page](https://github.com/clearlinux/distribution) and click on ['issues'](https://github.com/clearlinux/distribution/issues). The ['New Issue'](https://github.com/clearlinux/distribution/issues/new/choose) button will let you to quickly categorize between [Bug report](https://github.com/clearlinux/distribution/issues/new?assignees=&labels=bug%2C+new&template=bug_report.md&title=), [Enhancement](https://github.com/clearlinux/distribution/issues/new?assignees=&labels=enhancement%2C+new&template=enhancement-request.md&title=) or [Package](https://github.com/clearlinux/distribution/issues/new?assignees=&labels=new%2C+package-request&template=package-request.md&title=) requests


### PR DESCRIPTION
got the feedback that the statment "only used to track generic non-package specific issues" might be read as "do not fill issues regarding SW failures happening in CLR" so I wanted to make the readme more explicit